### PR TITLE
Fix all single quotes in the story name instead of only the first

### DIFF
--- a/src/pmdl.js
+++ b/src/pmdl.js
@@ -43,7 +43,7 @@ PMDL = function() {
     return template
       .replace(/{{ID}}/, storyId(story))
       .replace(/{{URL}}/, storyUrl(story))
-      .replace(/{{NAME}}/, storyName(story).replace(/'/, "’"));
+      .replace(/{{NAME}}/, storyName(story).replace(/'/g, "’"));
   }
 
   function createMDButton(baseButton) {


### PR DESCRIPTION
Some story names could be cut off previously, if the name had more than one straight single quote `'`. Now all straight single quotes will be replaced with curly quotes to avoid truncating the story name.